### PR TITLE
move template to org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: Bug
+about: Use this template to capture a bug.
+title: "Bug: ..."
+labels: bug
+---
+# Description
+
+_write a description of the bug_
+
+# Acceptance Criteria
+
+_create a checklist of acceptance criteria_
+
+- [ ] This is something that can be verified to show that this bug is satisfied.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,24 @@
+---
+name: Epic
+about: Use this template to capture an epic.
+title: ... Epic
+labels: epic
+---
+# Description
+
+_write a description of the epic_
+
+Note: _leave any notes or remove if not needed_
+
+# Acceptance Criteria
+
+_create a checklist of acceptance criteria_
+
+- [ ] Some criteria or user story
+
+# Linked User Stories
+
+_link user stories across repos or within repos to address the above criteria or user story_
+
+- [ ] [Link Some External User Story](https://github.com/terasenselabs/aaron-nonsense-repo/issues/3)
+- [ ] [Link an Internal User Story](#8)

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,23 @@
+---
+name: Story
+about: Use this template to capture a story.
+title: ... wants to ..., so they can ...
+labels: story
+---
+# Description
+As a ..., I want to ..., so I can ...
+
+*Ideally, this is in the issue title, but if not, you can put it here. If so, delete this section.*
+
+# Acceptance Criteria
+
+_create a checklist of acceptance criteria_
+
+- [ ] This is something that can be verified to show that this story is satisfied.
+
+# Sprint Ready Checklist 
+1. - [ ] Acceptance criteria defined 
+2. - [ ] Team understands acceptance criteria 
+3. - [ ] Team has defined solution / steps to satisfy acceptance criteria 
+4. - [ ] Acceptance criteria is verifiable / testable 
+5. - [ ] External / 3rd Party dependencies identified 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Task
+about: Use this template to capture a task.
+title: "Task: ..."
+labels: task
+---
+# Description
+
+_write a description of the task_
+
+# Acceptance Criteria
+
+_create a checklist of acceptance criteria_
+
+- [ ] This is something that can be verified to show that this task is satisfied.


### PR DESCRIPTION
Moving the issue templates to an org scope.

@ts-aaron Github currently does not support setting the project through templates. The only workaround is through actions.